### PR TITLE
Remove Source Files from ESP-IDF Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,3 @@
-set(COMPONENT_SRCDIRS
-  "http-parser"
-)
 
 set(COMPONENT_ADD_INCLUDEDIRS
   "http-parser/"


### PR DESCRIPTION
ESP-IDF is already compiling http-parser into it,
so we only need the header files for esp-homekit to compile.

Not sure why this only shows up now after the parser files got replaced by a submodule though.